### PR TITLE
feat: hosts login page for puppeteer usage

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,10 @@ import UsersService from "@/services/Users";
 import type { AuthenticationMethods } from "@/types";
 import ky from "ky";
 
+// We export it from here to make sure it points to the root folder,
+// and not the current file where it is called;
+export const _dirname = import.meta.dirname;
+
 export default class PumpFun {
 	static baseApiUrl = "https://frontend-api-v3.pump.fun";
 	coins: CoinsService;

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,9 +5,7 @@ import UsersService from "@/services/Users";
 import type { AuthenticationMethods } from "@/types";
 import ky from "ky";
 
-// We export it from here to make sure it points to the root folder,
-// and not the current file where it is called;
-export const _dirname = import.meta.dirname;
+export const rootDirname = import.meta.dirname;
 
 export default class PumpFun {
 	static baseApiUrl = "https://frontend-api-v3.pump.fun";

--- a/src/services/Auth/Phantom/index.ts
+++ b/src/services/Auth/Phantom/index.ts
@@ -10,7 +10,9 @@ import setupFileServer from "@/utils/setupFileServer";
 // biome-ignore lint/complexity/noStaticOnlyClass: This service is going to have more methods in the future;
 export default class PhantomService {
 	static async connect() {
-		const server = setupFileServer(path.join(rootDirname, "phantom.html"));
+		const server = setupFileServer(
+			path.join(rootDirname, "public/phantom-login.html"),
+		);
 		server.listen(5500, () => console.debug("login page listening on 5500"));
 
 		return await new Promise((resolve, reject) => {

--- a/src/services/Auth/Phantom/index.ts
+++ b/src/services/Auth/Phantom/index.ts
@@ -10,10 +10,13 @@ import setupFileServer from "@/utils/setupFileServer";
 // biome-ignore lint/complexity/noStaticOnlyClass: This service is going to have more methods in the future;
 export default class PhantomService {
 	static async connect() {
-		const server = setupFileServer(
+		const loginPagePort = 5500;
+		const loginPageServer = setupFileServer(
 			path.join(rootDirname, "public/phantom-login.html"),
 		);
-		server.listen(5500, () => console.debug("login page listening on 5500"));
+		loginPageServer.listen(loginPagePort, () =>
+			console.debug("login page listening on 5500"),
+		);
 
 		return await new Promise((resolve, reject) => {
 			// @TODO: Support other browsers;
@@ -34,7 +37,7 @@ export default class PhantomService {
 						});
 
 						const page = await browser.newPage();
-						await page.goto("http://localhost:5500");
+						await page.goto(`http://localhost:${loginPagePort}`);
 
 						// @TODO: Retry logic (e.g. message api);
 						const result = await page.evaluate(async () => {
@@ -58,10 +61,12 @@ export default class PhantomService {
 							},
 							json: encodedResult,
 						});
-						server.close(() => console.debug("closing login page server"));
+						loginPageServer.close(() =>
+							console.debug("closing login page server"),
+						);
 						resolve(response.json());
 					} catch (e) {
-						server.close(() =>
+						loginPageServer.close(() =>
 							console.debug("closing login page server due to error:", e),
 						);
 						reject(e);

--- a/src/services/Auth/Phantom/index.ts
+++ b/src/services/Auth/Phantom/index.ts
@@ -15,7 +15,7 @@ export default class PhantomService {
 			path.join(rootDirname, "public/phantom-login.html"),
 		);
 		loginPageServer.listen(loginPagePort, () =>
-			console.debug("login page listening on 5500"),
+			console.debug(`login page listening on ${loginPagePort}`),
 		);
 
 		return await new Promise((resolve, reject) => {

--- a/src/services/Auth/Phantom/index.ts
+++ b/src/services/Auth/Phantom/index.ts
@@ -3,11 +3,16 @@ import type { PhantomWindow } from "@/services/Auth/Phantom/types";
 import puppeteer from "puppeteer-core";
 import bs58 from "bs58";
 import ky from "ky";
-import PumpFun from "@/index";
+import PumpFun, { _dirname } from "@/index";
+import path from "node:path";
+import setupFileServer from "@/utils/setupFileServer";
 
 // biome-ignore lint/complexity/noStaticOnlyClass: This service is going to have more methods in the future;
 export default class PhantomService {
 	static async connect() {
+		const server = setupFileServer(path.join(_dirname, "phantom.html"));
+		server.listen(5500, () => console.debug("login page listening on 5500"));
+
 		return await new Promise((resolve, reject) => {
 			// @TODO: Support other browsers;
 			exec(
@@ -20,41 +25,45 @@ export default class PhantomService {
 
 					await new Promise((r) => setTimeout(r, 1000));
 
-					const browser = await puppeteer.connect({
-						browserURL: "http://localhost:9222",
-						defaultViewport: null,
-					});
+					try {
+						const browser = await puppeteer.connect({
+							browserURL: "http://localhost:9222",
+							defaultViewport: null,
+						});
 
-					const page = await browser.newPage();
-					await page.goto(
-						// @TODO: Find a way to host this file locally (e.g. live-server);
-						"http://127.0.0.1:5500/src/public/phantom-login.html",
-					);
+						const page = await browser.newPage();
+						await page.goto("http://localhost:5500");
 
-					// @TODO: Retry logic (e.g. message api);
-					const result = await page.evaluate(async () => {
-						const phantomWindow = window as unknown as PhantomWindow;
-						return phantomWindow.connectAndSign?.();
-					});
+						// @TODO: Retry logic (e.g. message api);
+						const result = await page.evaluate(async () => {
+							const phantomWindow = window as unknown as PhantomWindow;
+							return phantomWindow.connectAndSign?.();
+						});
 
-					if (result) {
-						await page.close();
+						if (result) {
+							await page.close();
+						}
+
+						const encodedResult = {
+							...result,
+							signature: bs58.encode(Object.values(result.signature)),
+						};
+
+						const response = ky.post(`${PumpFun.baseApiUrl}/auth/login`, {
+							headers: {
+								"content-type": "application/json",
+								origin: "https://pump.fun",
+							},
+							json: encodedResult,
+						});
+						server.close(() => console.debug("closing login page server"));
+						resolve(response.json());
+					} catch (e) {
+						server.close(() =>
+							console.debug("closing login page server due to error:", e),
+						);
+						reject(e);
 					}
-
-					const encodedResult = {
-						...result,
-						signature: bs58.encode(Object.values(result.signature)),
-					};
-
-					// @TODO: This should set cookies for next requests;
-					const response = ky.post(`${PumpFun.baseApiUrl}/auth/login`, {
-						headers: {
-							"content-type": "application/json",
-							origin: "https://pump.fun",
-						},
-						json: encodedResult,
-					});
-					resolve(response.json());
 				},
 			);
 		});

--- a/src/services/Auth/Phantom/index.ts
+++ b/src/services/Auth/Phantom/index.ts
@@ -3,14 +3,14 @@ import type { PhantomWindow } from "@/services/Auth/Phantom/types";
 import puppeteer from "puppeteer-core";
 import bs58 from "bs58";
 import ky from "ky";
-import PumpFun, { _dirname } from "@/index";
+import PumpFun, { rootDirname } from "@/index";
 import path from "node:path";
 import setupFileServer from "@/utils/setupFileServer";
 
 // biome-ignore lint/complexity/noStaticOnlyClass: This service is going to have more methods in the future;
 export default class PhantomService {
 	static async connect() {
-		const server = setupFileServer(path.join(_dirname, "phantom.html"));
+		const server = setupFileServer(path.join(rootDirname, "phantom.html"));
 		server.listen(5500, () => console.debug("login page listening on 5500"));
 
 		return await new Promise((resolve, reject) => {

--- a/src/utils/setupFileServer.ts
+++ b/src/utils/setupFileServer.ts
@@ -1,0 +1,16 @@
+import http from "node:http";
+import fs from "node:fs";
+
+export default function setupFileServer(filePath: string) {
+	return http.createServer((req, res) => {
+		fs.readFile(filePath, (err, data) => {
+			if (err) {
+				res.writeHead(500);
+				res.end("Error loading the file");
+				return;
+			}
+			res.writeHead(200, { "Content-Type": "text/html" });
+			res.end(data);
+		});
+	});
+}


### PR DESCRIPTION
Some extensions, specially Phantom, don't run automatically on `file://` html pages. And you can even set that configuration, however that's too manual and the ideal scenario would be for the library to be plug and play, so the solution is to temporarily host the login page while the authentication is happening and then closing once it is finished.

This pr accomplishes this by using node http server.