### PR TITLE
feat: login is now asynchronous

### DIFF
--- a/src/public/phantom-login.html
+++ b/src/public/phantom-login.html
@@ -125,10 +125,14 @@
         address,
         ...signDetails,
       }
+      window.postMessage({
+        type: 'SIGNATURE',
+        ...result
+      }, window.location.origin);
       return result;
     };
 
-    window.connectAndSign = connectAndSign;
+    connectAndSign();
   </script>
 </body>
 </html>

--- a/src/services/Auth/Phantom/types.ts
+++ b/src/services/Auth/Phantom/types.ts
@@ -1,16 +1,6 @@
-type Address = string;
-
-export interface PhantomWindow extends Window {
-	connectPhantomWallet: () => Promise<Address>;
-
-	signMessage: () => Promise<{
-		signature: Record<number, number>;
-		timestamp: number;
-	}>;
-
-	connectAndSign: () => Promise<{
-		address: Address;
-		signature: Record<number, number>;
-		timestamp: number;
-	}>;
+export interface PhantomSignatureEvent {
+	type: "SIGNATURE";
+	address: string;
+	signature: Record<number, number>;
+	timestamp: number;
 }


### PR DESCRIPTION
Closes #3 

Previously you had one chance to log in, and if you cancelled or closed the popup, the application stopped because of a failure reading the login info that was supposed to be there.

In order to make so the user can have the time they want to decide, the code now waits for a "signature" event from the page, therefore you can cancel or dismiss the popup how many times you want, it will still work when you finally sign in.