### PR TITLE
feat: credentials are now cached and reused until failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ dist
 node_modules
 .env
 .npmrc
+.cache

--- a/src/services/Auth/Phantom/index.ts
+++ b/src/services/Auth/Phantom/index.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import setupFileServer from "@/utils/setupFileServer";
 import AuthService from "..";
 import BrowserService from "@/services/Browser";
+import type { PhantomLoginBody } from "../types";
 
 // biome-ignore lint/complexity/noStaticOnlyClass: This service is going to have more methods in the future;
 export default class PhantomService {
@@ -20,7 +21,7 @@ export default class PhantomService {
 			console.debug(`login page listening on ${loginPagePort}`),
 		);
 
-		return await browserService.runOnBrowser(async (browser) => {
+		return (await browserService.runOnBrowser(async (browser) => {
 			try {
 				const page = await browser.newPage();
 				await page.goto(`http://localhost:${loginPagePort}`);
@@ -45,13 +46,14 @@ export default class PhantomService {
 					signature: bs58.encode(Object.values(result.signature)),
 				};
 				loginPageServer.close(() => console.debug("closing login page server"));
-				return authService.login(encodedResult);
+				await authService.login(encodedResult);
+				return encodedResult;
 			} catch (e) {
 				loginPageServer.close(() =>
 					console.debug("closing login page server due to error:", e),
 				);
 				return e;
 			}
-		});
+		})) as Promise<PhantomLoginBody>;
 	}
 }

--- a/src/services/Auth/types.ts
+++ b/src/services/Auth/types.ts
@@ -1,6 +1,6 @@
 import type { Profile } from "@/models/Profile";
 
-interface PhantomLoginBody {
+export interface PhantomLoginBody {
 	address: string;
 	signature: string;
 	timestamp: number;

--- a/src/utils/localCache.ts
+++ b/src/utils/localCache.ts
@@ -1,0 +1,54 @@
+import path from "node:path";
+import { rootDirname } from "..";
+import fs from "node:fs";
+
+// biome-ignore lint/suspicious/noExplicitAny: CacheValue is any by design
+type CacheValue = any;
+
+export class LocalCache {
+	static folder: string;
+	private fileName: string;
+	private filePath: string;
+
+	private checkPaths() {
+		if (!fs.existsSync(LocalCache.folder)) {
+			fs.mkdirSync(LocalCache.folder);
+		}
+		if (!fs.existsSync(path.join(LocalCache.folder, this.fileName))) {
+			fs.writeFileSync(path.join(LocalCache.folder, this.fileName), "{}");
+		}
+	}
+
+	constructor(fileName: `${string}.json`) {
+		LocalCache.folder = path.join(rootDirname, "../.cache");
+		this.fileName = fileName;
+		this.filePath = path.join(LocalCache.folder, this.fileName);
+		this.checkPaths();
+	}
+
+	set(key: string, value: CacheValue): void {
+		this.checkPaths();
+
+		const file = fs.readFileSync(this.filePath, "utf-8");
+		const data = JSON.parse(file);
+		data[key] = value;
+		fs.writeFileSync(this.filePath, JSON.stringify(data, null, 2));
+	}
+
+	get(key: string): CacheValue | undefined {
+		this.checkPaths();
+
+		const file = fs.readFileSync(this.filePath, "utf-8");
+		const data = JSON.parse(file);
+		return data[key];
+	}
+
+	delete(key: string): void {
+		this.checkPaths();
+
+		const file = fs.readFileSync(this.filePath, "utf-8");
+		const data = JSON.parse(file);
+		delete data[key];
+		fs.writeFileSync(this.filePath, JSON.stringify(data, null, 2));
+	}
+}


### PR DESCRIPTION
Closes #10 

This works by creating a file `.cache/user.json` and storing credentials there.
If the provider you chose to authenticate is the same as before, and there are credentials saved, it tries to log in with them first, and just if they fail it will request you to manually log in.
