### PR TITLE
feat: support additional browsers

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
 	"types": "dist/index.d.ts",
 	"type": "module",
 	"scripts": {
+		"start": "node dist/index.js",
 		"dev": "cross-env NODEMON=true nodemon",
 		"build": "tsc && tsc-alias && npm run copy-files",
 		"format": "pnpm biome format --write src/**/*",

--- a/src/services/Auth/Phantom/index.ts
+++ b/src/services/Auth/Phantom/index.ts
@@ -52,7 +52,7 @@ export default class PhantomService {
 				loginPageServer.close(() =>
 					console.debug("closing login page server due to error:", e),
 				);
-				return e;
+				throw e;
 			}
 		})) as Promise<PhantomLoginBody>;
 	}

--- a/src/services/Browser/browsers.ts
+++ b/src/services/Browser/browsers.ts
@@ -1,4 +1,4 @@
-export type SupportedBrowserId = "google";
+export type SupportedBrowserId = "google" | "brave";
 
 export type SupportedBrowsers = {
 	[key in SupportedBrowserId]: {
@@ -24,6 +24,14 @@ export const SUPPORTED_BROWSERS: SupportedBrowsers = {
 			linux: "google-chrome",
 			darwin: "Google Chrome",
 			win32: "chrome",
+		},
+	},
+	brave: {
+		label: "Brave",
+		platforms: {
+			linux: "brave-browser",
+			darwin: "Brave Browser",
+			win32: "brave",
 		},
 	},
 };

--- a/src/services/Browser/browsers.ts
+++ b/src/services/Browser/browsers.ts
@@ -1,4 +1,4 @@
-export type SupportedBrowserId = "google" | "brave";
+export type SupportedBrowserId = "google" | "brave" | "edge";
 
 export type SupportedBrowsers = {
 	[key in SupportedBrowserId]: {
@@ -32,6 +32,14 @@ export const SUPPORTED_BROWSERS: SupportedBrowsers = {
 			linux: "brave-browser",
 			darwin: "Brave Browser",
 			win32: "brave",
+		},
+	},
+	edge: {
+		label: "Microsoft Edge",
+		platforms: {
+			linux: "microsoft-edge",
+			darwin: "Microsoft Edge",
+			win32: "msedge",
 		},
 	},
 };

--- a/src/services/Browser/browsers.ts
+++ b/src/services/Browser/browsers.ts
@@ -1,4 +1,4 @@
-export type SupportedBrowserId = "google" | "brave" | "edge";
+export type SupportedBrowserId = "google" | "brave" | "edge" | "opera";
 
 export type SupportedBrowsers = {
 	[key in SupportedBrowserId]: {
@@ -40,6 +40,14 @@ export const SUPPORTED_BROWSERS: SupportedBrowsers = {
 			linux: "microsoft-edge",
 			darwin: "Microsoft Edge",
 			win32: "msedge",
+		},
+	},
+	opera: {
+		label: "Opera",
+		platforms: {
+			linux: "opera",
+			darwin: "Opera",
+			win32: "opera",
 		},
 	},
 };

--- a/src/services/Browser/browsers.ts
+++ b/src/services/Browser/browsers.ts
@@ -10,11 +10,11 @@ export type SupportedBrowsers = {
 };
 
 /**
- * @description Currently we only support chromium-based browsers that are able
- * to open more than a window simultaneously. We plan to support more browsers
- * in the future.
+ * @description Currently we only support chromium-based browsers because of a
+ * puppeteer limitation. And other alternatives such as `playwright` are not
+ * able to use extensions, so they don't work either.
  *
- * Also feel free to add other platforms, you just need to check what's the
+ * Feel free to add other platforms, you just need to check what's the
  * keyword to open the browser.
  */
 export const SUPPORTED_BROWSERS: SupportedBrowsers = {
@@ -23,6 +23,7 @@ export const SUPPORTED_BROWSERS: SupportedBrowsers = {
 		platforms: {
 			linux: "google-chrome",
 			darwin: "Google Chrome",
+			win32: "chrome",
 		},
 	},
 };

--- a/src/services/Browser/index.ts
+++ b/src/services/Browser/index.ts
@@ -27,6 +27,8 @@ export default class BrowserService {
 				return `open -a '${browserConfig.platforms.darwin}' --args --remote-debugging-port=9222`;
 			case "linux":
 				return `${browserConfig.platforms.linux} --remote-debugging-port=9222`;
+			case "win32":
+				return `start ${browserConfig.platforms.win32} --remote-debugging-port=9222`;
 			default:
 				throw new Error("Unsupported platform");
 		}


### PR DESCRIPTION
Relates to #2

Adds support to more browsers:
- Google chrome (Windows)
- Opera
- Edge
- Brave

Also, aditionally, does:
- Caches browser selection, showing the previous browser selected at first, to make a smoother experience
- Creates a more robust logic to handle browser initialization compared to the "wait 1s" implemented before